### PR TITLE
Fixes #PAPI-25: Add Source IP and User Agent to Integration Request headers

### DIFF
--- a/currencyfair.yaml
+++ b/currencyfair.yaml
@@ -356,6 +356,8 @@ paths:
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Content-Type: "method.request.header.Content-Type"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           200:
             statusCode: 200
@@ -401,6 +403,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           200:
             statusCode: 200
@@ -460,6 +464,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.querystring.account: "method.request.querystring.account"
           integration.request.querystring.currencyCode: "method.request.querystring.currencyCode"
         responses:
@@ -519,6 +525,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.id: "method.request.path.id"
         responses:
           200:
@@ -594,6 +602,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.querystring.include_disabled: "method.request.querystring.include_disabled"
           integration.request.querystring.cf_client_account: "method.request.querystring.cf_client_account"
           integration.request.querystring.account: "method.request.querystring.account"
@@ -643,6 +653,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.currencyCode: "method.request.path.currencyCode"
         responses:
           200:
@@ -696,6 +708,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           201:
             statusCode: 201
@@ -739,6 +753,8 @@ paths:
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
           integration.request.path.userId: "method.request.path.userId"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           200:
             statusCode: 200
@@ -784,6 +800,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
         responses:
           200:
@@ -831,6 +849,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.currencyCode: "method.request.path.currencyCode"
         responses:
@@ -880,6 +900,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           201:
             statusCode: 201
@@ -934,6 +956,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           200:
             statusCode: 200
@@ -1017,6 +1041,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.querystring.page: "method.request.querystring.page"
           integration.request.querystring.page_size: "method.request.querystring.page_size"
@@ -1060,6 +1086,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.orderId: "method.request.path.orderId"
         responses:
@@ -1110,6 +1138,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.orderId: "method.request.path.orderId"
         responses:
@@ -1158,6 +1188,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.orderId: "method.request.path.orderId"
         responses:
@@ -1203,6 +1235,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.orderId: "method.request.path.orderId"
         responses:
@@ -1248,6 +1282,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           200:
             statusCode: 200
@@ -1295,6 +1331,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.currencyFrom: "method.request.path.currencyFrom"
           integration.request.path.currencyTo: "method.request.path.currencyTo"
         responses:
@@ -1345,6 +1383,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           200:
             statusCode: 200
@@ -1407,6 +1447,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
         responses:
           201:
@@ -1450,6 +1492,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.querystring.page: "method.request.querystring.page"
           integration.request.querystring.page_size: "method.request.querystring.page_size"
@@ -1508,6 +1552,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.id: "method.request.path.id"
         responses:
@@ -1560,6 +1606,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.id: "method.request.path.id"
         responses:
@@ -1606,6 +1654,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           200:
             statusCode: 200
@@ -1649,6 +1699,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.currencyCode: "method.request.path.currencyCode"
         responses:
           200:
@@ -1709,6 +1761,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
         responses:
           201:
@@ -1759,6 +1813,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.querystring.page: "method.request.querystring.page"
           integration.request.querystring.status: "method.request.querystring.status"
@@ -1816,6 +1872,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.transferId: "method.request.path.transferId"
         responses:
@@ -1880,6 +1938,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.transferId: "method.request.path.transferId"
         responses:
@@ -1924,6 +1984,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           200:
             statusCode: 200
@@ -1971,6 +2033,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.querystring.currencyCode: "method.request.querystring.currencyCode"
         responses:
           200:
@@ -2023,6 +2087,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.querystring.excludeFreeTransfer: "method.request.querystring.excludeFreeTransfer"
         responses:
           200:
@@ -2068,6 +2134,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
         responses:
           200:
@@ -2112,6 +2180,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.accountId: "method.request.path.accountId"
         responses:
@@ -2158,6 +2228,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.accountId: "method.request.path.accountId"
         responses:
@@ -2213,6 +2285,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.accountId: "method.request.path.accountId"
         responses:
@@ -2261,6 +2335,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.accountId: "method.request.path.accountId"
         responses:
@@ -2303,6 +2379,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
         responses:
           200:
@@ -2383,6 +2461,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.x-cf-mfa-followon-id: "method.request.path.x-cf-mfa-followon-id"
           integration.request.path.x-cf-mfa-device-id: "method.request.path.x-cf-mfa-device-id"
@@ -2440,6 +2520,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.countryId: "method.request.path.countryId"
           integration.request.querystring.currency: "method.request.querystring.currency"
         responses:
@@ -2526,6 +2608,8 @@ paths:
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Content-Type: "method.request.header.Content-Type"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           200:
             statusCode: 200
@@ -2571,6 +2655,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           200:
             statusCode: 200
@@ -2627,6 +2713,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
         responses:
           200:
@@ -2700,6 +2788,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.querystring.status: "method.request.querystring.status"
         responses:
@@ -2752,6 +2842,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.querystring.filter: "method.request.querystring.filter"
         responses:
           200:
@@ -2800,6 +2892,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.statusId: "method.request.path.statusId"
         responses:
           200:
@@ -2846,6 +2940,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.id: "method.request.path.id"
         responses:
@@ -2894,6 +2990,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.currencyCode: "method.request.path.currencyCode"
         responses:
@@ -2942,6 +3040,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.currencyCode: "method.request.path.currencyCode"
         responses:
@@ -3012,6 +3112,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.fromCurrencyCode: "method.request.path.fromCurrencyCode"
           integration.request.path.transferType: "method.request.path.transferType"
@@ -3058,6 +3160,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
         responses:
           200:
             statusCode: 200
@@ -3106,6 +3210,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.id: "method.request.path.id"
         responses:
           200:
@@ -3152,6 +3258,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.countryId: "method.request.path.countryId"
         responses:
           200:
@@ -3207,6 +3315,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.currencyCode: "method.request.path.currencyCode"
           integration.request.querystring.amount: "method.request.querystring.amount"
@@ -3267,6 +3377,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.currencyCode: "method.request.path.currencyCode"
           integration.request.path.transferCurrency: "method.request.path.transferCurrency"
@@ -3313,6 +3425,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.transferId: "method.request.path.transferId"
         responses:
@@ -3374,6 +3488,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.transferId: "method.request.path.transferId"
         responses:
@@ -3422,6 +3538,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
         responses:
           201:
@@ -3462,6 +3580,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
         responses:
           200:
@@ -3504,6 +3624,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
         responses:
           200:
@@ -3548,6 +3670,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.id: "method.request.path.id"
         responses:
@@ -3594,6 +3718,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.id: "method.request.path.id"
         responses:
@@ -3634,6 +3760,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.id: "method.request.path.id"
         responses:
@@ -3694,6 +3822,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.querystring.context: "method.request.querystring.context"
           integration.request.querystring.currency: "method.request.querystring.currency"
@@ -3759,6 +3889,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.path.transactionId: "method.request.path.transactionId"
           integration.request.querystring.context: "method.request.querystring.context"
@@ -3820,6 +3952,8 @@ paths:
           integration.request.header.Authorization: "method.request.header.Authorization"
           integration.request.header.xsapi-gateway-key: "stageVariables.gatewayKey"
           integration.request.header.Accept-Language: "method.request.header.Accept-Language"
+          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
+          integration.request.header.User-Agent: "context.identity.userAgent"
           integration.request.path.userId: "method.request.path.userId"
           integration.request.querystring.format: "method.request.querystring.format"
           integration.request.querystring.context: "method.request.querystring.context"


### PR DESCRIPTION
Adds the following requestParameters to the `x-amazon-apigateway-integration` vendor extension:

```
          integration.request.header.X-Forwarded-For: "context.identity.sourceIp"
          integration.request.header.User-Agent: "context.identity.userAgent"
```