### PR TITLE
Fixes #PAPI-34: Clarify use of float for amount querystring property

### DIFF
--- a/currencyfair.yaml
+++ b/currencyfair.yaml
@@ -1441,7 +1441,9 @@ paths:
           description: Verification of amount that should be cancelled.
           required: true
           schema:
-            type: string
+            type: number
+            format: float
+            example: "500.00"
       responses:
         '204':
           description: Order successfully cancelled.


### PR DESCRIPTION
This PR clarifies that the `amount` required query string property in the deleteUsersOrder operation should be a float rather than an integer